### PR TITLE
fix: stop sending google analytics traffic to blog.johnnyreilly.com

### DIFF
--- a/config/presets.js
+++ b/config/presets.js
@@ -10,10 +10,6 @@ module.exports = [
         ignorePatterns: ['/tags/**'],
         filename: 'sitemap.xml',
       },
-      gtag: {
-        trackingID: 'G-226F0LR9KE',
-        anonymizeIP: true,
-      },
       googleAnalytics: {
         trackingID: 'UA-141789564-1',
         anonymizeIP: true,


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->

This PR will stop your docs site sending traffic data to Google Analytics against blog.johnnyreilly.com

Copy paste means that's whats happening. 

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information

https://twitter.com/johnny_reilly/status/1590585546451333120

I'm trying to get the Docusaurus docs fixed as well.
https://github.com/facebook/docusaurus/pull/8313
